### PR TITLE
Update 2022-04-03-sheikhlar22a.md

### DIFF
--- a/_posts/2022-04-03-sheikhlar22a.md
+++ b/_posts/2022-04-03-sheikhlar22a.md
@@ -39,7 +39,7 @@ lastpage: 62
 page: 48-62
 order: 48
 cycles: false
-bibtex_author: Sheikhlar, Arash and Th{\'o}orisson, Kristinn R. and Thompson, Jeff
+bibtex_author: Sheikhlar, Arash and Th{\'o}risson, Kristinn R. and Thompson, Jeff
 author:
 - given: Arash
   family: Sheikhlar
@@ -49,7 +49,7 @@ author:
   family: Thompson
 date: 2022-04-03
 address:
-container-title: Proceedings of The 2nd International Conference on Examples
+container-title: Proceedings of the Third International Workshop on Self-Supervised Learning
 volume: '192'
 genre: inproceedings
 issued:


### PR DESCRIPTION
Removed extra 'o' from 'Th{\'o}orisson' - changed to 'Th{\'o}risson'. 
Updated the 'container-title' to 'Proceedings of the Third International Workshop on Self-Supervised Learning'.