### PR TITLE
Update 2022-04-03-thorisson22a.md

### DIFF
--- a/_posts/2022-04-03-thorisson22a.md
+++ b/_posts/2022-04-03-thorisson22a.md
@@ -1,5 +1,6 @@
 ---
 title: 'IWSSL: Introduction to this volume'
+abstract: The papers in this collection were presented at the third annual International Workshop on Self-Supervised Learning (IWSSL-22), held at Reykjavik University in Reykjavik, Iceland, on July 28th and 29th, 2022. Weighing in together at a total of 127 pages, these 10 papers of exceptional quality describe leading AI research from Europe and the USA, both theoretical and applied. The challenges they focus on, and the many foundational ideas proposed to address them, are sure to be at the center of all significant advances in AI research in the coming decades.
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 publisher: PMLR
@@ -18,7 +19,7 @@ author:
   family: Thórisson
 date: 2022-04-03
 address:
-container-title: Proceedings of The 2nd International Conference on Examples
+container-title: Proceedings of the Third International Workshop on Self-Supervised Learning
 volume: '192'
 genre: inproceedings
 issued:


### PR DESCRIPTION
Added missing abstract. Updated the 'container-title' to 'Proceedings of the Third International Workshop on Self-Supervised Learning'.